### PR TITLE
Update to Cranelift 0.33.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ name = "toy"
 path = "src/toy.rs"
 
 [dependencies]
-cranelift = "0.25.0"
-cranelift-module = "0.25.0"
-cranelift-simplejit = "0.25.0"
+cranelift = "0.33.0"
+cranelift-module = "0.33.0"
+cranelift-simplejit = "0.33.0"
 peg = "0.5.4"
 
 [build-dependencies]

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -33,7 +33,7 @@ impl JIT {
             unimplemented!();
         }
 
-        let builder = SimpleJITBuilder::new();
+        let builder = SimpleJITBuilder::new(cranelift_module::default_libcall_names());
         let module = Module::new(builder);
         Self {
             builder_context: FunctionBuilderContext::new(),
@@ -94,7 +94,7 @@ impl JIT {
         self.data_ctx.define(contents.into_boxed_slice());
         let id = self
             .module
-            .declare_data(name, Linkage::Export, true)
+            .declare_data(name, Linkage::Export, true, None)
             .map_err(|e| e.to_string())?;
 
         self.module
@@ -393,7 +393,7 @@ impl<'a> FunctionTranslator<'a> {
     fn translate_global_data_addr(&mut self, name: String) -> Value {
         let sym = self
             .module
-            .declare_data(&name, Linkage::Export, true)
+            .declare_data(&name, Linkage::Export, true, None)
             .expect("problem declaring data object");
         let local_id = self
             .module


### PR DESCRIPTION
As far as I could tell, simplejit-demo doesn't need alignment on either of the declare_data calls - at least there was presumably no alignment constraints when using Cranelift 0.25.0.

All my edits were single line edits, so none of the line numbers in README.md should need updating.