### PR TITLE
Update for basic blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ name = "toy"
 path = "src/toy.rs"
 
 [dependencies]
-cranelift = "0.33.0"
-cranelift-module = "0.33.0"
-cranelift-simplejit = "0.33.0"
+cranelift = "0.58.0"
+cranelift-module = "0.58.0"
+cranelift-simplejit = "0.58.0"
 peg = "0.6"
-

--- a/README.md
+++ b/README.md
@@ -116,14 +116,14 @@ Both functions and data objects can contain references to other functions and
 data objects. Cranelift is designed to allow the low-level parts operate on each
 function and data object independently, so each function and data object maintains
 its own individual namespace of imported names. The
-[`Module`](https://docs.rs/cranelift-module/0.25.0/cranelift_module/struct.Module.html)
+[`Module`](https://docs.rs/cranelift-module/latest/cranelift_module/struct.Module.html)
 struct takes care of maintaining a set of declarations for use across multiple
 functions and data objects.
 
 These concepts are sufficiently general that they're applicable to JITing as
 well as native object files (more discussion below!), and `Module` provides an
 interface which abstracts over both. It is parameterized with a
-[`Backend`](https://docs.rs/cranelift-module/0.25.0/cranelift_module/trait.Backend.html)
+[`Backend`](https://docs.rs/cranelift-module/latest/cranelift_module/trait.Backend.html)
 trait, which allows users to specify what underlying implementation they want to use.
 
 Once we've
@@ -152,7 +152,7 @@ to the Cranelift function signature.
 Then we
 [create](./src/jit.rs#L129)
 a
-[FunctionBuilder](https://docs.rs/cranelift-frontend/0.25.0/cranelift_frontend/struct.FunctionBuilder.html)
+[FunctionBuilder](https://docs.rs/cranelift-frontend/latest/cranelift_frontend/struct.FunctionBuilder.html)
 which is a utility for building up the contents of a Cranelift IR function. As we'll
 see below, `FunctionBuilder` includes functionality for constructing SSA form
 automatically so that users don't have to worry about it.
@@ -189,7 +189,7 @@ them directly generally don't need to worry about them, though one place they
 do come up is that incoming arguments to a function are represented as
 block parameters to the entry block. We must tell Cranelift to add the parameters,
 using
-[`append_block_params_for_function_params`](https://docs.rs/cranelift-frontend/0.25.0/cranelift_frontend/struct.FunctionBuilder.html#method.append_block_params_for_function_params)
+[`append_block_params_for_function_params`](https://docs.rs/cranelift-frontend/latest/cranelift_frontend/struct.FunctionBuilder.html#method.append_block_params_for_function_params)
 like
 [so](./src/jit.rs#L135).
 
@@ -197,7 +197,7 @@ The `FunctionBuilder` keeps track of a "current" block that new instructions are
 to be inserted into; we next
 [inform](./src/jit.rs#L141)
 it of our new block, using
-[`switch_to_block`](https://docs.rs/cranelift-frontend/0.25.0/cranelift_frontend/struct.FunctionBuilder.html#method.switch_to_block),
+[`switch_to_block`](https://docs.rs/cranelift-frontend/latest/cranelift_frontend/struct.FunctionBuilder.html#method.switch_to_block),
 so that we can start
 inserting instructions into it.
 
@@ -207,7 +207,7 @@ all branches which could branch to a block have been seen, at which point it can
 sealed by the end of the function. We
 [seal](./src/jit.rs#L144)
 a block with
-[`seal_block`](https://docs.rs/cranelift-frontend/0.25.0/cranelift_frontend/struct.FunctionBuilder.html#method.seal_block).
+[`seal_block`](https://docs.rs/cranelift-frontend/latest/cranelift_frontend/struct.FunctionBuilder.html#method.seal_block).
 
 Next, our toy language doesn't have explicit variable declarations, so we walk the
 AST to discover all the variables, so that we can

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -130,26 +130,26 @@ impl JIT {
         let mut builder = FunctionBuilder::new(&mut self.ctx.func, &mut self.builder_context);
 
         // Create the entry block, to start emitting code in.
-        let entry_ebb = builder.create_ebb();
+        let entry_block = builder.create_block();
 
         // Since this is the entry block, add block parameters corresponding to
         // the function's parameters.
         //
         // TODO: Streamline the API here.
-        builder.append_ebb_params_for_function_params(entry_ebb);
+        builder.append_block_params_for_function_params(entry_block);
 
         // Tell the builder to emit code in this block.
-        builder.switch_to_block(entry_ebb);
+        builder.switch_to_block(entry_block);
 
         // And, tell the builder that this block will have no further
         // predecessors. Since it's the entry block, it won't have any
         // predecessors.
-        builder.seal_block(entry_ebb);
+        builder.seal_block(entry_block);
 
         // The toy language allows variables to be declared implicitly.
         // Walk the AST and declare all implicitly-declared variables.
         let variables =
-            declare_variables(int, &mut builder, &params, &the_return, &stmts, entry_ebb);
+            declare_variables(int, &mut builder, &params, &the_return, &stmts, entry_block);
 
         // Now translate the statements of the function body.
         let mut trans = FunctionTranslator {
@@ -291,24 +291,28 @@ impl<'a> FunctionTranslator<'a> {
             Expr::IfElse(condition, then_body, else_body) => {
                 let condition_value = self.translate_expr(*condition);
 
-                let else_block = self.builder.create_ebb();
-                let merge_block = self.builder.create_ebb();
+                let then_block = self.builder.create_block();
+                let else_block = self.builder.create_block();
+                let merge_block = self.builder.create_block();
 
                 // If-else constructs in the toy language have a return value.
                 // In traditional SSA form, this would produce a PHI between
                 // the then and else bodies. Cranelift uses block parameters,
                 // so set up a parameter in the merge block, and we'll pass
                 // the return values to it from the branches.
-                self.builder.append_ebb_param(merge_block, self.int);
+                self.builder.append_block_param(merge_block, self.int);
 
                 // Test the if condition and conditionally branch.
                 self.builder.ins().brz(condition_value, else_block, &[]);
+                // Fall through to then block.
+                self.builder.ins().jump(then_block, &[]);
 
+                self.builder.switch_to_block(then_block);
+                self.builder.seal_block(then_block);
                 let mut then_return = self.builder.ins().iconst(self.int, 0);
                 for expr in then_body {
                     then_return = self.translate_expr(expr);
                 }
-
                 // Jump to the merge block, passing it the block return value.
                 self.builder.ins().jump(merge_block, &[then_return]);
 
@@ -330,19 +334,25 @@ impl<'a> FunctionTranslator<'a> {
 
                 // Read the value of the if-else by reading the merge block
                 // parameter.
-                let phi = self.builder.ebb_params(merge_block)[0];
+                let phi = self.builder.block_params(merge_block)[0];
 
                 phi
             }
 
             Expr::WhileLoop(condition, loop_body) => {
-                let header_block = self.builder.create_ebb();
-                let exit_block = self.builder.create_ebb();
+                let header_block = self.builder.create_block();
+                let body_block = self.builder.create_block();
+                let exit_block = self.builder.create_block();
+
                 self.builder.ins().jump(header_block, &[]);
                 self.builder.switch_to_block(header_block);
 
                 let condition_value = self.translate_expr(*condition);
                 self.builder.ins().brz(condition_value, exit_block, &[]);
+                self.builder.ins().jump(body_block, &[]);
+
+                self.builder.switch_to_block(body_block);
+                self.builder.seal_block(body_block);
 
                 for expr in loop_body {
                     self.translate_expr(expr);
@@ -410,7 +420,7 @@ fn declare_variables(
     params: &[String],
     the_return: &str,
     stmts: &[Expr],
-    entry_ebb: Ebb,
+    entry_block: Block,
 ) -> HashMap<String, Variable> {
     let mut variables = HashMap::new();
     let mut index = 0;
@@ -418,7 +428,7 @@ fn declare_variables(
     for (i, name) in params.iter().enumerate() {
         // TODO: cranelift_frontend should really have an API to make it easy to set
         // up param variables.
-        let val = builder.ebb_params(entry_ebb)[i];
+        let val = builder.block_params(entry_block)[i];
         let var = declare_variable(int, builder, &mut variables, &mut index, name);
         builder.def_var(var, val);
     }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -313,6 +313,7 @@ impl<'a> FunctionTranslator<'a> {
                 for expr in then_body {
                     then_return = self.translate_expr(expr);
                 }
+
                 // Jump to the merge block, passing it the block return value.
                 self.builder.ins().jump(merge_block, &[then_return]);
 


### PR DESCRIPTION
This PR resolves #39 and update cranelift version to 0.52.0.
But I have two concerns related to updating for basic blocks.

1. At what timing should we update document related to (extended) basic blocks? Cranelift now seems  on inconsistent state about basic blocks. For example, cranlift-simplejit doesn't use basic blocks feature although other modules already using the feature as default. And I think it's better to wait until https://github.com/bytecodealliance/cranelift/issues/1303 is resolved to prevent rewriting document over and over.
2. Should we indicate some caution about current state of cranelift untill its transition is fully completed?