### PR TITLE
Cranelift now supports Windows calling conventions.

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -28,11 +28,6 @@ pub struct JIT {
 impl JIT {
     /// Create a new `JIT` instance.
     pub fn new() -> Self {
-        // Windows calling conventions are not supported yet.
-        if cfg!(windows) {
-            unimplemented!();
-        }
-
         let builder = SimpleJITBuilder::new(cranelift_module::default_libcall_names());
         let module = Module::new(builder);
         Self {


### PR DESCRIPTION
Cranelift now supports the [Windows x64 calling convention](https://github.com/bytecodealliance/wasmtime/blob/86ff6d7aef8017da4b77b9b8d69a71c4a2b443cb/cranelift/codegen/src/isa/call_conv.rs#L17), and according to https://github.com/bytecodealliance/simplejit-demo/issues/6, the simplejit-demo project now works on Windows, so remove the check for Windows. If there are any issues on Windows, please file issues!