### PR TITLE
update cranelift version to 0.63.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "toy"
 path = "src/toy.rs"
 
 [dependencies]
-cranelift = "0.58.0"
-cranelift-module = "0.58.0"
-cranelift-simplejit = "0.58.0"
+cranelift = "0.63.0"
+cranelift-module = "0.63.0"
+cranelift-simplejit = "0.63.0"
 peg = "0.6"

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -65,7 +65,7 @@ impl JIT {
         // defined. For this toy demo for now, we'll just finalize the function
         // below.
         self.module
-            .define_function(id, &mut self.ctx)
+            .define_function(id, &mut self.ctx, &mut codegen::binemit::NullTrapSink {})
             .map_err(|e| e.to_string())?;
 
         // Now that compilation is finished, we can clear out the context state.
@@ -89,7 +89,7 @@ impl JIT {
         self.data_ctx.define(contents.into_boxed_slice());
         let id = self
             .module
-            .declare_data(name, Linkage::Export, true, None)
+            .declare_data(name, Linkage::Export, true, false, None)
             .map_err(|e| e.to_string())?;
 
         self.module
@@ -399,7 +399,7 @@ impl<'a> FunctionTranslator<'a> {
     fn translate_global_data_addr(&mut self, name: String) -> Value {
         let sym = self
             .module
-            .declare_data(&name, Linkage::Export, true, None)
+            .declare_data(&name, Linkage::Export, true, false, None)
             .expect("problem declaring data object");
         let local_id = self
             .module


### PR DESCRIPTION
Update cranelift version to 0.63.0.
Some interfaces related to `cranelift-module` have changed, so this PR contains its adaptation.
By the way, `depandabot` seems not to work,  was this done on purpose?

@sunfishcode Could you review this please?