### PR TITLE
Ensure latest version of cranelift is getting used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "toy"
 path = "src/toy.rs"
 
 [dependencies]
-cranelift = "0.63.0"
-cranelift-module = "0.63.0"
-cranelift-simplejit = "0.63.0"
+cranelift = "0.66.0"
+cranelift-module = "0.66.0"
+cranelift-simplejit = "0.66.0"
 peg = "0.6"


### PR DESCRIPTION
A lot of outdated information can be found on the internet. In an environment evolving as fast as the Cranelift project, up-to-date documentation is crucial.

I therefore checked if the simplejit demo works with the latest version of Cranelift (it does) and want to help keeping the repo updates as well.