### PR TITLE
gh-59 Add example of calling rust code from JIT

### DIFF
--- a/src/bin/toy.rs
+++ b/src/bin/toy.rs
@@ -13,6 +13,8 @@ fn main() -> Result<(), String> {
         "iterative_fib(10) = {}",
         run_iterative_fib_code(&mut jit, 10)?
     );
+    println!("counting down from 5:");
+    run_countdown_code(&mut jit, 5)?;
     run_hello(&mut jit)?;
     Ok(())
 }
@@ -23,6 +25,10 @@ fn run_foo(jit: &mut jit::JIT) -> Result<isize, String> {
 
 fn run_recursive_fib_code(jit: &mut jit::JIT, input: isize) -> Result<isize, String> {
     unsafe { run_code(jit, RECURSIVE_FIB_CODE, input) }
+}
+
+fn run_countdown_code(jit: &mut jit::JIT, input: isize) -> Result<isize, String> {
+    unsafe { run_code(jit, COUNTDOWN_CODE, input) }
 }
 
 fn run_iterative_fib_code(jit: &mut jit::JIT, input: isize) -> Result<isize, String> {
@@ -85,6 +91,18 @@ const RECURSIVE_FIB_CODE: &str = r#"
                 } else {
                     recursive_fib(n - 1) + recursive_fib(n - 2)
                 }
+            }
+    }
+"#;
+
+/// Another example: calling our builtin print functon.
+const COUNTDOWN_CODE: &str = r#"
+    fn countdown(n) -> (r) {
+        r = if n == 0 {
+                    0
+            } else {
+                print(n)
+                countdown(n - 1)
             }
     }
 "#;

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -467,7 +467,7 @@ fn declare_variable(
 
 // Prints a value used by the compiled code. Our JIT exposes this
 // function to compiled code with the name "print".
-fn print_internal(value: isize) -> isize {
+extern "C" fn print_internal(value: isize) -> isize {
     println!("{}", value);
     0
 }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -26,7 +26,13 @@ pub struct JIT {
 
 impl Default for JIT {
     fn default() -> Self {
-        let builder = JITBuilder::new(cranelift_module::default_libcall_names());
+        let mut builder = JITBuilder::new(cranelift_module::default_libcall_names());
+
+        // Register our print function with the JIT so that it can be
+        // called from code.
+        let print_addr = print_internal as *const u8;
+        builder.symbol("print", print_addr);
+
         let module = JITModule::new(builder);
         Self {
             builder_context: FunctionBuilderContext::new(),
@@ -457,4 +463,11 @@ fn declare_variable(
         *index += 1;
     }
     var
+}
+
+// Prints a value used by the compiled code. Our JIT exposes this
+// function to compiled code with the name "print".
+fn print_internal(value: isize) -> isize {
+    println!("{}", value);
+    0
 }


### PR DESCRIPTION
This adds an example of calling a simple print function from the JIT. The print function is written in Rust and this demonstrates how to call functions declared in the host program from the JIT.