### PR TITLE
Update deps to cranelift 0.97 and peg 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ description = "Toy language implemented using cranelift-jit"
 edition = "2018"
 
 [dependencies]
-peg = "0.6"
-cranelift = "0.93.0"
-cranelift-module = "0.93.0"
-cranelift-jit = "0.93.0"
-cranelift-native = "0.93.0"
+peg = "0.8.1"
+cranelift = "0.97.1"
+cranelift-module = "0.97.1"
+cranelift-jit = "0.97.1"
+cranelift-native = "0.97.1"

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The `JIT` class is defined [here](./src/jit.rs#L9) and contains several fields:
  - `builder_context` - Cranelift uses this to reuse dynamic allocations between
    compiling multiple functions.
  - `ctx` - This is the main `Context` object for compiling functions.
- - `data_ctx` - Similar to `ctx`, but for "compiling" data sections.
+ - `data_description` - Similar to `ctx`, but for "compiling" data sections.
  - `module` - The `Module` which holds information about all functions and data
    objects defined in the current `JIT`.
 
@@ -368,9 +368,9 @@ And there's a hello world example which demonstrates several other features.
 
 This program needs to allocate some [data](./src/toy.rs#L33) to hold the string
 data. Inside jit.rs, [`create_data`](./src/jit.rs#L95) we initialize a
-`DataContext` with the contents of the hello string, and also declare a data
-object. Then we use the `DataContext` object to define the object.  At that
-point, we're done with the `DataContext` object and can clear it. We then call
+`DataDescription` with the contents of the hello string, and also declare a data
+object. Then we use the `DataDescription` object to define the object.  At that
+point, we're done with the `DataDescription` object and can clear it. We then call
 `finalize_data` to perform linking (although our simple hello string doesn't
 make any references so there isn't anything to do) and to obtain the final
 runtime address of the data, which we then convert back into a Rust slice for

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1,7 +1,7 @@
 use crate::frontend::*;
 use cranelift::prelude::*;
 use cranelift_jit::{JITBuilder, JITModule};
-use cranelift_module::{DataContext, Linkage, Module};
+use cranelift_module::{DataDescription, Linkage, Module};
 use std::collections::HashMap;
 use std::slice;
 
@@ -17,7 +17,7 @@ pub struct JIT {
     ctx: codegen::Context,
 
     /// The data context, which is to data objects what `ctx` is to functions.
-    data_ctx: DataContext,
+    data_ctx: DataDescription,
 
     /// The module, with the jit backend, which manages the JIT'd
     /// functions.
@@ -41,7 +41,7 @@ impl Default for JIT {
         Self {
             builder_context: FunctionBuilderContext::new(),
             ctx: module.make_context(),
-            data_ctx: DataContext::new(),
+            data_ctx: DataDescription::new(),
             module,
         }
     }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -16,8 +16,8 @@ pub struct JIT {
     /// context per thread, though this isn't in the simple demo here.
     ctx: codegen::Context,
 
-    /// The data context, which is to data objects what `ctx` is to functions.
-    data_ctx: DataDescription,
+    /// The data description, which is to data objects what `ctx` is to functions.
+    data_description: DataDescription,
 
     /// The module, with the jit backend, which manages the JIT'd
     /// functions.
@@ -41,7 +41,7 @@ impl Default for JIT {
         Self {
             builder_context: FunctionBuilderContext::new(),
             ctx: module.make_context(),
-            data_ctx: DataDescription::new(),
+            data_description: DataDescription::new(),
             module,
         }
     }
@@ -95,16 +95,16 @@ impl JIT {
     pub fn create_data(&mut self, name: &str, contents: Vec<u8>) -> Result<&[u8], String> {
         // The steps here are analogous to `compile`, except that data is much
         // simpler than functions.
-        self.data_ctx.define(contents.into_boxed_slice());
+        self.data_description.define(contents.into_boxed_slice());
         let id = self
             .module
             .declare_data(name, Linkage::Export, true, false)
             .map_err(|e| e.to_string())?;
 
         self.module
-            .define_data(id, &self.data_ctx)
+            .define_data(id, &self.data_description)
             .map_err(|e| e.to_string())?;
-        self.data_ctx.clear();
+        self.data_description.clear();
         self.module.finalize_definitions().unwrap();
         let buffer = self.module.get_finalized_data(id);
         // TODO: Can we move the unsafe into cranelift?


### PR DESCRIPTION
The tutorial requires minor changes to compile with the current version of cranelift (0.97).

`cranelift_module::DataContext` does not seem to exist anymore. It used to wrap a `DataDescription` instance. The latter is now exported via `cranelift_module` and using it instead works fine.

This PR makes the necessary changes and also updates the README accordingly.